### PR TITLE
Allow HTML content in tooltip

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'lookback:tooltips',
   summary: 'Reactive tooltips.',
-  version: '0.3.0',
+  version: '0.3.1',
   git: 'https://github.com/lookback/meteor-tooltips.git'
 });
 

--- a/tooltips.html
+++ b/tooltips.html
@@ -1,7 +1,7 @@
 <template name="tooltips">
 	<div class="tooltip {{direction}} {{display}}" style="{{position}}">
 		{{#if content}}
-			<div class="inner">{{content}}</div>
+			<div class="inner">{{{content}}}</div>
 		{{/if}}
 	</div>
 </template>


### PR DESCRIPTION
A tiny change to allow the user to supply HTML content for the tooltip, as you can't pass a Spacebars.SafeString object through HTML attributes (it's just passed through as a string literal), so you need to use triple-braces in the actual template to render HTML properly.
